### PR TITLE
Do not get chart content for diff

### DIFF
--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -36,7 +36,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	pathutil "path"
 	"sync"
 	"time"
@@ -203,14 +202,6 @@ func (server *MultiTenantServer) fetchChartsInStorage(log cm_logger.LoggingFn, r
 	filteredObjects := []cm_storage.Object{}
 	for _, object := range allObjects {
 		if object.HasExtension(cm_repo.ChartPackageFileExtension) {
-			log(cm_logger.DebugLevel, "GetObject From Storage Backend", "repo", repo, "path", object.Path)
-			// Since ListObject cannot fetch the content from file list
-			objectDetail, err := server.StorageBackend.GetObject(pathutil.Join(repo, object.Path))
-			if err != nil {
-				return nil, fmt.Errorf("backend storage: chart not found: %q", err)
-			}
-			// do not change other object field except content
-			object.Content = objectDetail.Content
 			filteredObjects = append(filteredObjects, object)
 		}
 	}


### PR DESCRIPTION
When creating the index.yaml for a repository the server fetched the content of the charts twice.
One time when fetching all charts from the storage backend, then determining the diff between cache and backend and then fetch the charts again.
This leads to slower index regeneration and higher costs for backend requests. 
The metadata required for the determination of the objectSliceDiff should already be included in the ListObject response so we only have to read the whole file from the backend when it is changed.